### PR TITLE
feat(ai): Implement and prioritize Vengeance Mode for Impossible AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,13 +629,18 @@
 
                             console.log("Impossible AI: Checking for Goblin synergy.");
                             const availableGoblins = remainingHeroes.filter(h => h.name.includes('Goblin'));
-                            if (availableGoblins.length >= Math.min(3, this.state.teamSize)) {
+                            // Vengeance mode should override goblin synergy preference.
+                            if (!this.state.vengeanceMode && availableGoblins.length >= Math.min(3, this.state.teamSize)) {
                                 console.log("Impossible AI: Goblin synergy found. Selecting Goblin team.");
                                 this.state.player2Team = availableGoblins
                                     .sort((a,b) => getPowerScore(b) - getPowerScore(a))
                                     .slice(0, this.state.teamSize);
                             } else {
-                                console.log("Impossible AI: No synergy found. Building counter-team.");
+                                if (this.state.vengeanceMode) {
+                                    console.log("Impossible AI: Vengeance mode overrides synergy. Building dedicated counter-team.");
+                                } else {
+                                    console.log("Impossible AI: No synergy found. Building counter-team.");
+                                }
                                 const playerWeakness = Object.keys(playerTypes).sort((a, b) => playerTypes[b] - playerTypes[a])[0];
                                 const primaryCounterType = counterType[playerWeakness];
 


### PR DESCRIPTION
This change introduces a "learning" mechanism for the Impossible AI, called Vengeance Mode, and ensures it takes priority over other strategies.

- When the player defeats the Impossible AI, their team composition is saved to the browser's localStorage.
- When a new game is started against the Impossible AI, it checks if the player's current team has been recorded in the loss history.
- If a match is found, the AI enters "Vengeance Mode".
- In this mode, the AI's team selection logic is modified to heavily prioritize picking heroes that have a type advantage against the player's team.
- Vengeance Mode now correctly overrides the AI's default tendency to pick a Goblin synergy team, ensuring it focuses on building a dedicated counter-team.